### PR TITLE
Parse GPRMC Sentence Codes

### DIFF
--- a/lib/boat_tracker/application.ex
+++ b/lib/boat_tracker/application.ex
@@ -11,9 +11,7 @@ defmodule BoatTracker.Application do
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: BoatTracker.Supervisor]
-
-    # Children for all targets
-    children = [GPS | children(target())]
+    children = children(target())
 
     Supervisor.start_link(children, opts)
   end
@@ -32,6 +30,7 @@ defmodule BoatTracker.Application do
       # Children for all targets except host
       # Starts a worker by calling: BoatTracker.Worker.start_link(arg)
       # {BoatTracker.Worker, arg},
+      GPS
     ]
   end
 

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -13,7 +13,8 @@ defmodule BoatTracker.Sentences.Parser do
         status: parse_string(Enum.at(content_list, 1)),
         latitude: parse_latitude(Enum.at(content_list, 2), Enum.at(content_list, 3)),
         longitude: parse_longitude(Enum.at(content_list, 4), Enum.at(content_list, 5)),
-        speed: parse_float(Enum.at(content_list, 6))
+        speed: parse_float(Enum.at(content_list, 6)),
+        track_angle: parse_float(Enum.at(content_list, 7))
       }
     end
   end

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -1,7 +1,7 @@
 defmodule BoatTracker.Sentences.Parser do
   alias BoatTracker.Sentences.RMC
 
-  @rmc_content_size 12
+  @rmc_content_size 11
   @time_size 6
 
   def parse("$GPRMC," <> content) do
@@ -12,7 +12,8 @@ defmodule BoatTracker.Sentences.Parser do
         time: parse_time(Enum.at(content_list, 0)),
         status: parse_string(Enum.at(content_list, 1)),
         latitude: parse_latitude(Enum.at(content_list, 2), Enum.at(content_list, 3)),
-        longitude: parse_longitude(Enum.at(content_list, 4), Enum.at(content_list, 5))
+        longitude: parse_longitude(Enum.at(content_list, 4), Enum.at(content_list, 5)),
+        speed: parse_float(Enum.at(content_list, 6))
       }
     end
   end
@@ -82,4 +83,12 @@ defmodule BoatTracker.Sentences.Parser do
 
   defp longitude_to_decimal_degrees(degrees, minutes, "E"), do: degrees + minutes / 60.0
   defp longitude_to_decimal_degrees(degrees, minutes, "W"), do: (degrees + minutes / 60.0) * -1.0
+
+  defp parse_float(""), do: nil
+
+  defp parse_float(value) do
+    value
+    |> Float.parse()
+    |> elem(0)
+  end
 end

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -10,7 +10,8 @@ defmodule BoatTracker.Sentences.Parser do
     if valid_content_size?(:rmc, content_list) do
       %RMC{
         time: parse_time(Enum.at(content_list, 0)),
-        status: parse_string(Enum.at(content_list, 1))
+        status: parse_string(Enum.at(content_list, 1)),
+        latitude: parse_latitude(Enum.at(content_list, 2), Enum.at(content_list, 3))
       }
     end
   end
@@ -42,4 +43,23 @@ defmodule BoatTracker.Sentences.Parser do
 
   defp parse_string(""), do: nil
   defp parse_string(value), do: value
+
+  defp parse_latitude("", ""), do: nil
+
+  defp parse_latitude(string, bearing) do
+    {deg, _} =
+      string
+      |> String.slice(0, 2)
+      |> Float.parse()
+
+    {min, _} =
+      string
+      |> String.slice(2, 100)
+      |> Float.parse()
+
+    lat_to_decimal_degrees(deg, min, bearing)
+  end
+
+  defp lat_to_decimal_degrees(degrees, minutes, "N"), do: degrees + minutes / 60.0
+  defp lat_to_decimal_degrees(degrees, minutes, "S"), do: (degrees + minutes / 60.0) * -1.0
 end

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -1,0 +1,15 @@
+defmodule BoatTracker.Sentences.Parser do
+  alias BoatTracker.Sentences.RMC
+
+  @rmc_content_size 12
+
+  def parse("$GPRMC," <> content) do
+    content_list = String.split(content, ",")
+
+    if valid_content_size?(:rmc, content_list) do
+      %RMC{}
+    end
+  end
+
+  defp valid_content_size?(:rmc, content), do: Enum.count(content) == @rmc_content_size
+end

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -1,10 +1,14 @@
 defmodule BoatTracker.Sentences.Parser do
+  @moduledoc """
+  NMEA sentences parser module.
+  """
   alias BoatTracker.Sentences.RMC
 
   @rmc_content_size 11
   @time_size 6
   @date_size 6
 
+  @spec parse(String.t()) :: RMC.t() | nil
   def parse("$GPRMC," <> content) do
     content_list = String.split(content, ",")
 

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -11,7 +11,8 @@ defmodule BoatTracker.Sentences.Parser do
       %RMC{
         time: parse_time(Enum.at(content_list, 0)),
         status: parse_string(Enum.at(content_list, 1)),
-        latitude: parse_latitude(Enum.at(content_list, 2), Enum.at(content_list, 3))
+        latitude: parse_latitude(Enum.at(content_list, 2), Enum.at(content_list, 3)),
+        longitude: parse_longitude(Enum.at(content_list, 4), Enum.at(content_list, 5))
       }
     end
   end
@@ -57,9 +58,28 @@ defmodule BoatTracker.Sentences.Parser do
       |> String.slice(2, 100)
       |> Float.parse()
 
-    lat_to_decimal_degrees(deg, min, bearing)
+    latitude_to_decimal_degrees(deg, min, bearing)
   end
 
-  defp lat_to_decimal_degrees(degrees, minutes, "N"), do: degrees + minutes / 60.0
-  defp lat_to_decimal_degrees(degrees, minutes, "S"), do: (degrees + minutes / 60.0) * -1.0
+  defp latitude_to_decimal_degrees(degrees, minutes, "N"), do: degrees + minutes / 60.0
+  defp latitude_to_decimal_degrees(degrees, minutes, "S"), do: (degrees + minutes / 60.0) * -1.0
+
+  defp parse_longitude("", ""), do: nil
+
+  defp parse_longitude(string, bearing) do
+    {deg, _} =
+      string
+      |> String.slice(0, 3)
+      |> Float.parse()
+
+    {min, _} =
+      string
+      |> String.slice(3, 100)
+      |> Float.parse()
+
+    longitude_to_decimal_degrees(deg, min, bearing)
+  end
+
+  defp longitude_to_decimal_degrees(degrees, minutes, "E"), do: degrees + minutes / 60.0
+  defp longitude_to_decimal_degrees(degrees, minutes, "W"), do: (degrees + minutes / 60.0) * -1.0
 end

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -8,7 +8,10 @@ defmodule BoatTracker.Sentences.Parser do
     content_list = String.split(content, ",")
 
     if valid_content_size?(:rmc, content_list) do
-      %RMC{time: parse_time(Enum.at(content_list, 0))}
+      %RMC{
+        time: parse_time(Enum.at(content_list, 0)),
+        status: parse_string(Enum.at(content_list, 1))
+      }
     end
   end
 
@@ -36,4 +39,7 @@ defmodule BoatTracker.Sentences.Parser do
   end
 
   defp parse_hours_minutes_seconds_ms(_), do: nil
+
+  defp parse_string(""), do: nil
+  defp parse_string(value), do: value
 end

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -16,7 +16,8 @@ defmodule BoatTracker.Sentences.Parser do
         longitude: parse_longitude(Enum.at(content_list, 4), Enum.at(content_list, 5)),
         speed: parse_float(Enum.at(content_list, 6)),
         track_angle: parse_float(Enum.at(content_list, 7)),
-        date: parse_date(Enum.at(content_list, 8))
+        date: parse_date(Enum.at(content_list, 8)),
+        magnetic_variation: parse_float(Enum.at(content_list, 9))
       }
     end
   end

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -2,14 +2,38 @@ defmodule BoatTracker.Sentences.Parser do
   alias BoatTracker.Sentences.RMC
 
   @rmc_content_size 12
+  @time_size 6
 
   def parse("$GPRMC," <> content) do
     content_list = String.split(content, ",")
 
     if valid_content_size?(:rmc, content_list) do
-      %RMC{}
+      %RMC{time: parse_time(Enum.at(content_list, 0))}
     end
   end
 
   defp valid_content_size?(:rmc, content), do: Enum.count(content) == @rmc_content_size
+
+  defp parse_time(time) when byte_size(time) < @time_size, do: nil
+
+  defp parse_time(time) do
+    time
+    |> String.split(".")
+    |> parse_hours_minutes_seconds_ms()
+  end
+
+  defp parse_hours_minutes_seconds_ms([<<main::binary-size(@time_size)>>]),
+    do: parse_hours_minutes_seconds_ms([main, "0"])
+
+  defp parse_hours_minutes_seconds_ms([<<main::binary-size(@time_size)>>, millis]) do
+    {ms, _} = Integer.parse(millis)
+    {h, _} = Integer.parse(String.slice(main, 0, 2))
+    {m, _} = Integer.parse(String.slice(main, 2, 2))
+    {s, _} = Integer.parse(String.slice(main, 4, 2))
+    {:ok, time} = Time.new(h, m, s, ms)
+
+    time
+  end
+
+  defp parse_hours_minutes_seconds_ms(_), do: nil
 end

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -22,6 +22,8 @@ defmodule BoatTracker.Sentences.Parser do
     end
   end
 
+  def parse(_invalid_sentence), do: nil
+
   defp valid_content_size?(:rmc, content), do: Enum.count(content) == @rmc_content_size
 
   defp parse_time(time) when byte_size(time) < @time_size, do: nil

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -3,6 +3,7 @@ defmodule BoatTracker.Sentences.Parser do
 
   @rmc_content_size 11
   @time_size 6
+  @date_size 6
 
   def parse("$GPRMC," <> content) do
     content_list = String.split(content, ",")
@@ -14,7 +15,8 @@ defmodule BoatTracker.Sentences.Parser do
         latitude: parse_latitude(Enum.at(content_list, 2), Enum.at(content_list, 3)),
         longitude: parse_longitude(Enum.at(content_list, 4), Enum.at(content_list, 5)),
         speed: parse_float(Enum.at(content_list, 6)),
-        track_angle: parse_float(Enum.at(content_list, 7))
+        track_angle: parse_float(Enum.at(content_list, 7)),
+        date: parse_date(Enum.at(content_list, 8))
       }
     end
   end
@@ -88,8 +90,32 @@ defmodule BoatTracker.Sentences.Parser do
   defp parse_float(""), do: nil
 
   defp parse_float(value) do
-    value
-    |> Float.parse()
-    |> elem(0)
+    {float, _} = Float.parse(value)
+
+    float
   end
+
+  defp parse_date(<<raw_date::binary-size(@date_size)>>) do
+    {day, _} =
+      raw_date
+      |> String.slice(0, 2)
+      |> Integer.parse()
+
+    {month, _} =
+      raw_date
+      |> String.slice(2, 2)
+      |> Integer.parse()
+
+    {year, _} =
+      raw_date
+      |> String.slice(4, 2)
+      |> String.replace_prefix("", "20")
+      |> Integer.parse()
+
+    {:ok, date} = Date.new(year, month, day)
+
+    date
+  end
+
+  defp parse_date(_raw_date), do: nil
 end

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -8,6 +8,23 @@ defmodule BoatTracker.Sentences.Parser do
   @time_size 6
   @date_size 6
 
+  @doc """
+  Parses a NMEA sentence into a struct.
+
+  ## Examples
+
+    iex> BoatTracker.Sentences.Parser.parse("$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70")
+    %BoatTracker.Sentences.RMC{
+      date: ~D[2006-06-13],
+      latitude: 51.56366666666667,
+      longitude: -0.7040000000000001,
+      magnetic_variation: 4.2,
+      speed: 173.8,
+      status: "A",
+      time: ~T[22:05:16.000000],
+      track_angle: 231.8
+    }
+  """
   @spec parse(String.t()) :: RMC.t() | nil
   def parse("$GPRMC," <> content) do
     content_list = String.split(content, ",")

--- a/lib/boat_tracker/sentences/parser.ex
+++ b/lib/boat_tracker/sentences/parser.ex
@@ -53,16 +53,8 @@ defmodule BoatTracker.Sentences.Parser do
   defp parse_latitude("", ""), do: nil
 
   defp parse_latitude(string, bearing) do
-    {deg, _} =
-      string
-      |> String.slice(0, 2)
-      |> Float.parse()
-
-    {min, _} =
-      string
-      |> String.slice(2, 100)
-      |> Float.parse()
-
+    {deg, _} = Float.parse(String.slice(string, 0, 2))
+    {min, _} = Float.parse(String.slice(string, 2, 100))
     latitude_to_decimal_degrees(deg, min, bearing)
   end
 
@@ -72,16 +64,8 @@ defmodule BoatTracker.Sentences.Parser do
   defp parse_longitude("", ""), do: nil
 
   defp parse_longitude(string, bearing) do
-    {deg, _} =
-      string
-      |> String.slice(0, 3)
-      |> Float.parse()
-
-    {min, _} =
-      string
-      |> String.slice(3, 100)
-      |> Float.parse()
-
+    {deg, _} = Float.parse(String.slice(string, 0, 3))
+    {min, _} = Float.parse(String.slice(string, 3, 100))
     longitude_to_decimal_degrees(deg, min, bearing)
   end
 
@@ -97,22 +81,9 @@ defmodule BoatTracker.Sentences.Parser do
   end
 
   defp parse_date(<<raw_date::binary-size(@date_size)>>) do
-    {day, _} =
-      raw_date
-      |> String.slice(0, 2)
-      |> Integer.parse()
-
-    {month, _} =
-      raw_date
-      |> String.slice(2, 2)
-      |> Integer.parse()
-
-    {year, _} =
-      raw_date
-      |> String.slice(4, 2)
-      |> String.replace_prefix("", "20")
-      |> Integer.parse()
-
+    {day, _} = Integer.parse(String.slice(raw_date, 0, 2))
+    {month, _} = Integer.parse(String.slice(raw_date, 2, 2))
+    {year, _} = Integer.parse("20" <> String.slice(raw_date, 2, 2))
     {:ok, date} = Date.new(year, month, day)
 
     date

--- a/lib/boat_tracker/sentences/rmc.ex
+++ b/lib/boat_tracker/sentences/rmc.ex
@@ -1,0 +1,24 @@
+defmodule BoatTracker.Sentences.RMC do
+  # Example:
+  # $GPRMC,144728.000,A,5441.3992,N,02515.6704,E,1.37,38.57,190716,,,A*55
+  #   RMC          Recommended Minimum sentence C
+  #   144728.000   Fix taken at 12:35:19 UTC
+  #   A            Status A=active or V=Void.
+  #   5441.3992,N   Latitude 48 deg 07.038' N
+  #   02515.6704,E  Longitude 11 deg 31.000' E
+  #   1.37        Speed over the ground in knots
+  #   38.57        Track angle in degrees True
+  #   131202       Date - 13th of December 2002
+  #   (empty)      Magnetic Variation
+  #   (empty)
+  #   A            autonomous
+  #   *55          The checksum data, always begins with *
+  defstruct time: nil,
+            status: nil,
+            latitude: nil,
+            longitude: nil,
+            speed_over_groud: nil,
+            track_angle: nil,
+            date: nil,
+            magnetic_variation: nil
+end

--- a/lib/boat_tracker/sentences/rmc.ex
+++ b/lib/boat_tracker/sentences/rmc.ex
@@ -1,23 +1,9 @@
 defmodule BoatTracker.Sentences.RMC do
-  # Example:
-  # $GPRMC,144728.000,A,5441.3992,N,02515.6704,E,1.37,38.57,190716,,,A*55
-  #   RMC          Recommended Minimum sentence C
-  #   144728.000   Fix taken at 12:35:19 UTC
-  #   A            Status A=active or V=Void.
-  #   5441.3992,N   Latitude 48 deg 07.038' N
-  #   02515.6704,E  Longitude 11 deg 31.000' E
-  #   1.37        Speed over the ground in knots
-  #   38.57        Track angle in degrees True
-  #   131202       Date - 13th of December 2002
-  #   (empty)      Magnetic Variation
-  #   (empty)
-  #   A            autonomous
-  #   *55          The checksum data, always begins with *
   defstruct time: nil,
             status: nil,
             latitude: nil,
             longitude: nil,
-            speed_over_groud: nil,
+            speed: nil,
             track_angle: nil,
             date: nil,
             magnetic_variation: nil

--- a/lib/boat_tracker/sentences/rmc.ex
+++ b/lib/boat_tracker/sentences/rmc.ex
@@ -1,4 +1,23 @@
 defmodule BoatTracker.Sentences.RMC do
+  @moduledoc """
+  Recommended minimum specific GPS/Transit data.
+
+  $GPRMC,hhmmss.ss,A,llll.ll,a,yyyyy.yy,a,x.x,x.x,ddmmyy,x.x,a*hh
+            1      2     3   4     5    6  7   8    9     10 11 12
+
+  1    = UTC of position fix
+  2    = Data status (V=navigation receiver warning)
+  3    = Latitude of fix
+  4    = N or S
+  5    = Longitude of fix
+  6    = E or W
+  7    = Speed over ground in knots
+  8    = Track made good in degrees True
+  9    = UT date
+  10   = Magnetic variation degrees (Easterly var. subtracts from true course)
+  11   = E or W
+  12   = Checksum
+  """
   defstruct time: nil,
             status: nil,
             latitude: nil,

--- a/lib/boat_tracker/sentences/rmc.ex
+++ b/lib/boat_tracker/sentences/rmc.ex
@@ -6,7 +6,7 @@ defmodule BoatTracker.Sentences.RMC do
             1      2     3   4     5    6  7   8    9     10 11 12
 
   1    = UTC of position fix
-  2    = Data status (V=navigation receiver warning)
+  2    = Data status (A = OK, V = Navigation receiver warning)
   3    = Latitude of fix
   4    = N or S
   5    = Longitude of fix

--- a/test/sentences/parser_test.exs
+++ b/test/sentences/parser_test.exs
@@ -42,5 +42,15 @@ defmodule BoatTrackerTest.Sentences.ParserTest do
                track_angle: 231.8
              }
     end
+
+    test "parse invalid sentences" do
+      sentence_1 = "$GPRMC,081836,A,3751.65,S,14507.36,E,000.0,360.0,130998,011.3"
+      sentence_2 = "GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70"
+      sentence_3 = "Do you even sail?"
+
+      refute Parser.parse(sentence_1)
+      refute Parser.parse(sentence_2)
+      refute Parser.parse(sentence_3)
+    end
   end
 end

--- a/test/sentences/parser_test.exs
+++ b/test/sentences/parser_test.exs
@@ -1,0 +1,46 @@
+defmodule BoatTrackerTest.Sentences.ParserTest do
+  use ExUnit.Case
+
+  alias BoatTracker.Sentences.{Parser, RMC}
+
+  describe "Parse $GPRMC sentences" do
+    test "parse valid sentences" do
+      sentence_1 = "$GPRMC,081836,A,3751.65,S,14507.36,E,000.0,360.0,130998,011.3,E*62"
+      sentence_2 = "$GPRMC,225446,A,4916.45,N,12311.12,W,000.5,054.7,191194,020.3,E*68"
+      sentence_3 = "$GPRMC,220516,A,5133.82,N,00042.24,W,173.8,231.8,130694,004.2,W*70"
+
+      assert Parser.parse(sentence_1) == %RMC{
+               date: ~D[2009-09-13],
+               latitude: -37.86083333333333,
+               longitude: 145.12266666666667,
+               magnetic_variation: 11.3,
+               speed: 0.0,
+               status: "A",
+               time: ~T[08:18:36.000000],
+               track_angle: 360.0
+             }
+
+      assert Parser.parse(sentence_2) == %RMC{
+               date: ~D[2011-11-19],
+               latitude: 49.274166666666666,
+               longitude: -123.18533333333333,
+               magnetic_variation: 20.3,
+               speed: 0.5,
+               status: "A",
+               time: ~T[22:54:46.000000],
+               track_angle: 54.7
+             }
+
+      assert Parser.parse(sentence_3) == %RMC{
+               date: ~D[2006-06-13],
+               latitude: 51.56366666666667,
+               longitude: -0.7040000000000001,
+               magnetic_variation: 4.2,
+               speed: 173.8,
+               status: "A",
+               time: ~T[22:05:16.000000],
+               track_angle: 231.8
+             }
+    end
+  end
+end

--- a/test/sentences/parser_test.exs
+++ b/test/sentences/parser_test.exs
@@ -1,5 +1,6 @@
 defmodule BoatTrackerTest.Sentences.ParserTest do
   use ExUnit.Case
+  doctest BoatTracker.Sentences.Parser
 
   alias BoatTracker.Sentences.{Parser, RMC}
 


### PR DESCRIPTION
# Description

The following PR adds a new module for parsing GPRMC (Recommended minimum specific GPS/Transit data) sentences, along with  a proper struct for using this data. This parser is being created because eventually we will need to parse the sentences that are being received from the GPS modules and it seems like GPRMC is the recommended minimum data that will work for us in order to reach the initial MVP. Perhaps we will use other sentences in the near future, but at least having one will be convenient for us as we understand how to decouple the system effectively from the different nodes and the future UI it will have.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests have been added with valid and invalid sentences.

Used the following link as a documentation guide: 

http://aprs.gids.nl/nmea/#rmc

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules